### PR TITLE
Close Decision Scientist, reopen SWE position

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -199,50 +199,53 @@
       },
       "openPositions": [
         {
-          "slug": "decision-scientist-data-ai",
-          "title": "Decision Scientist – Data & AI Implementation",
+          "slug": "software-engineer-ai-llm",
+          "title": "Software Engineer, AI/LLM Platform",
           "location": "Buenos Aires (Hybrid) • Full-time",
-          "applicationUrl": "https://forms.gle/grhyoFSdbetVZZvCA",
+          "applicationUrl": "https://forms.gle/vbuJnRVXUoShqc8M9",
           "aboutNivii": [
-            "Imagine you are the leader of an area in a large company and it's monday morning. The results from last month have just come in and they are not what we were expecting... maybe margins are down, stock has gone up, talent is leaving faster or our products quality is suffering. What happened is something most companies know how to find, but why and what to do is much much harder and slower. You needed instant answers from deep within your data, but without them you keep using only your intuition.",
-            "At Nivii, we're rethinking how people interact with business data. Our conversational AI system lets users ask questions in natural language and receive clear, actionable answers—instantly and visually. By combining language models, data orchestration, and chart generation into a seamless interface, we help teams move from data to decisions faster than ever before. We haven't built a chatbot or another \"talk to your data\" — we've built a thinking partner, an evolution of consulting.",
-            "Our product is already live, serving real users across LATAM, with early traction from teams that need answers, not dashboards. We're a small, hands-on team based in Buenos Aires, passionate about usability, clarity, and helping people reason better with data."
+            "At Nivii.ai, we're building a new way for teams to work with data. Instead of dashboards and traditional BI, we're creating an AI-powered platform that allows users to ask complex business questions in natural language and receive structured, explainable, and actionable answers.",
+            "Over the past year, we've moved from concept to production: a multi-agent system that is already being used in real decision-making workflows. We're now looking for a Software Engineer, AI/LLM Platform to help us scale, harden, and evolve the core systems that power this platform."
           ],
           "aboutRole": [
-            "We're looking for someone to join Nivii's Decision Science team. We are the team that makes sure our agents give back really insightful answers. To do that we usually need to make sure they have clean, reliable inputs, sharp reasoning pathways and the right business context.",
-            "This is a hybrid role: part data, part analysis, part AI experimentation. Perfect for someone who loves variety and thrives in early-stage environments but who loves being able to have a material impact in our product and our client's business."
+            "This role is software-engineering-first, with AI and LLMs as core building blocks. You'll work very close to the product and the founders, owning critical parts of the platform end-to-end."
           ],
           "responsibilities": [
-            "Conduct data analysis: Look at the numbers, find meaningful patterns, and translate them into clear, actionable insights for the business",
-            "Iterate on agent development: Adjust prompts, refine reasoning, test improvements, run evaluations, and help our agents answer each day a little better",
-            "Design and develop creative internal tools: Build inventive, lightweight utilities and frameworks that push our data analysis forward—whether that's automating investigative workflows, surfacing insights faster, or crafting new ways for the team to interact with data",
-            "Help shape the product: Work closely with Engineering on product features and with our Commercial team to understand client needs and tune our AI systems to solve them effectively",
-            "Build and maintain data pipelines: Connect sources, model tables, ensure data quality, and keep our agents well-fed with clean, structured information"
+            "Design, build, and own core platform services that power our AI/LLM workflows",
+            "Develop and operate LLM-based systems (e.g. text-to-SQL, reasoning agents, planners), with a strong focus on reliability, performance, and cost",
+            "Build and maintain backend services and APIs that orchestrate complex, multi-step AI pipelines",
+            "Work hands-on with Kubernetes-based infrastructure, including deployments, scaling, and debugging production issues",
+            "Contribute to DevOps and MLOps workflows: CI/CD, environments, monitoring, logging, and operational best practices",
+            "Collaborate on architectural decisions around observability, failure handling, evaluation, and system trade-offs",
+            "Work closely with founders and product to translate real business problems into robust technical solutions"
           ],
           "requirements": [
-            "Really strong analytical background. Often people in this area have engineering, economist, planning or other data-driven roles",
-            "You are a very curious person who self teaches whenever is needed. In the cutting edge of Gen AI we often find that to solve a problem we need to learn new things",
-            "You tend to excel at breaking down problems and when you see something we could do better you try to fix it",
-            "You are an early adopter of AI (doesn't matter if you like ChatGPT, Claude or Grok) and you use it frequently... hopefully every day",
-            "You have a point of view about business. Maybe you could have gone into strategy consulting (maybe you did!) but at least with some group of people in your life you tend to have conversations about business",
-            "You are based in Buenos Aires, with availability for in-person collaboration once a week",
-            "Fluent in English and Spanish"
+            "4+ years of experience as a software engineer in backend, ML, or data-intensive systems",
+            "Strong software engineering mindset with proven experience shipping and maintaining production systems",
+            "Excellent Python skills and experience building backend services (FastAPI or similar)",
+            "Solid hands-on experience with Docker and Kubernetes in real-world environments",
+            "Basic to solid DevOps knowledge: CI/CD pipelines, cloud environments, logging, monitoring, and deployments",
+            "Experience with cloud platforms (AWS preferred)",
+            "Practical experience working with LLMs in applied settings (text-to-SQL, RAG, agent-based systems, or similar)",
+            "Ability to reason about and manage trade-offs (quality vs latency, cost vs performance, simplicity vs flexibility)",
+            "Strong communication skills in English"
           ],
           "bonusPoints": [
-            "Experience with Python or SQL",
-            "Experience with AI/LLMs (prompting, evaluations, LangChain/LangGraph, etc.)",
-            "Experience in data engineering (modeling, ETL/ELT, warehouse tools)"
+            "Experience with SQL databases, data platforms, or vector databases",
+            "Experience designing evaluation frameworks for ML or LLM systems",
+            "Previous experience in early-stage startups or high-ownership teams"
           ],
           "benefits": [
-            "Competitive compensation",
-            "A meaningful equity stake—shared ownership matters",
-            "Flexibility within a hybrid model",
-            "The chance to shape a product and an AI system from the ground up",
-            "A meaningful mission: making data useful to humans, not just analysts"
+            "Work on a real AI/LLM platform in production, not demos or research projects",
+            "High ownership and direct impact on the core technology and product direction",
+            "Equity + competitive salary",
+            "Fast growth path into senior or leadership responsibilities as the team scales",
+            "Hybrid work model based in Buenos Aires"
           ],
           "quickInfo": {
             "location": "Buenos Aires (Hybrid)",
-            "department": "Decision Science"
+            "experience": "4+ years",
+            "department": "Engineering"
           }
         }
       ]

--- a/messages/en.json
+++ b/messages/en.json
@@ -202,7 +202,7 @@
           "slug": "software-engineer-ai-llm",
           "title": "Software Engineer, AI/LLM Platform",
           "location": "Buenos Aires (Hybrid) • Full-time",
-          "applicationUrl": "https://forms.gle/vbuJnRVXUoShqc8M9",
+          "applicationUrl": "https://forms.gle/WVC4sHzKW2VfwALX9",
           "aboutNivii": [
             "At Nivii.ai, we're building a new way for teams to work with data. Instead of dashboards and traditional BI, we're creating an AI-powered platform that allows users to ask complex business questions in natural language and receive structured, explainable, and actionable answers.",
             "Over the past year, we've moved from concept to production: a multi-agent system that is already being used in real decision-making workflows. We're now looking for a Software Engineer, AI/LLM Platform to help us scale, harden, and evolve the core systems that power this platform."

--- a/messages/es.json
+++ b/messages/es.json
@@ -202,7 +202,7 @@
           "slug": "software-engineer-ai-llm",
           "title": "Software Engineer, AI/LLM Platform",
           "location": "Buenos Aires (Híbrido) • Full-time",
-          "applicationUrl": "https://forms.gle/vbuJnRVXUoShqc8M9",
+          "applicationUrl": "https://forms.gle/WVC4sHzKW2VfwALX9",
           "aboutNivii": [
             "En Nivii.ai estamos construyendo una nueva forma de trabajar con datos. En lugar de dashboards y BI tradicional, estamos creando una AI-powered platform que permite hacer preguntas complejas en lenguaje natural y obtener respuestas estructuradas, explicables y accionables.",
             "Durante el último año pasamos de concepto a producción: hoy contamos con un sistema multi-agent que ya se utiliza en flujos reales de toma de decisiones. Ahora buscamos sumar un/a Software Engineer, AI/LLM Platform para ayudarnos a escalar, robustecer y evolucionar los sistemas core que hacen funcionar la plataforma."

--- a/messages/es.json
+++ b/messages/es.json
@@ -199,50 +199,53 @@
       },
       "openPositions": [
         {
-          "slug": "decision-scientist-data-ai",
-          "title": "Decision Science – Data & AI Implementation",
+          "slug": "software-engineer-ai-llm",
+          "title": "Software Engineer, AI/LLM Platform",
           "location": "Buenos Aires (Híbrido) • Full-time",
-          "applicationUrl": "https://forms.gle/grhyoFSdbetVZZvCA",
+          "applicationUrl": "https://forms.gle/vbuJnRVXUoShqc8M9",
           "aboutNivii": [
-            "Imaginá que sos líder de un área en una gran compañía y es lunes a la mañana. Llegaron los resultados del mes pasado y no son los que esperábamos… tal vez bajaron los márgenes, subió el stock, el talento está rotando más rápido o la calidad del producto está sufriendo. Qué pasó es algo que la mayoría de las empresas sabe encontrar, pero el por qué y qué hacer es mucho más difícil y lento. Necesitabas respuestas profundas de tu data de manera instantánea, pero sin ellas volvés a depender solo de la intuición.",
-            "En Nivii estamos repensando cómo las personas interactúan con los datos de negocio. Nuestro sistema de AI conversacional permite hacer preguntas en lenguaje natural y recibir respuestas claras, accionables, instantáneas y visuales. Combinando language models, data orchestration y generación de gráficos en una sola interfaz, ayudamos a los equipos a pasar de datos a decisiones más rápido que nunca. No construimos un chatbot ni otro \"talk to your data\": construimos un thinking partner, una evolución del consulting tradicional.",
-            "Nuestro producto ya está en producción, con usuarios reales en toda LATAM y tracción temprana de equipos que necesitan respuestas, no dashboards. Somos un equipo pequeño, práctico, basado en Buenos Aires, apasionado por la usabilidad, la claridad y por ayudar a las personas a razonar mejor con datos."
+            "En Nivii.ai estamos construyendo una nueva forma de trabajar con datos. En lugar de dashboards y BI tradicional, estamos creando una AI-powered platform que permite hacer preguntas complejas en lenguaje natural y obtener respuestas estructuradas, explicables y accionables.",
+            "Durante el último año pasamos de concepto a producción: hoy contamos con un sistema multi-agent que ya se utiliza en flujos reales de toma de decisiones. Ahora buscamos sumar un/a Software Engineer, AI/LLM Platform para ayudarnos a escalar, robustecer y evolucionar los sistemas core que hacen funcionar la plataforma."
           ],
           "aboutRole": [
-            "Buscamos a alguien para sumarse al equipo de Decision Science. Somos el equipo que se asegura de que nuestros agentes devuelvan respuestas realmente profundas y útiles. Para lograrlo, necesitamos garantizar que tengan insumos limpios y confiables, caminos de razonamiento bien diseñados y el contexto de negocio adecuado.",
-            "Es un rol híbrido: parte data, parte análisis, parte experimentación con AI. Ideal para alguien que disfrute la variedad, prospere en entornos early-stage y quiera generar un impacto material en nuestro producto y en el negocio de nuestros clientes."
+            "Este rol es software-engineering-first, con AI y LLM como building blocks centrales. Vas a trabajar muy cerca del producto y de los founders, con ownership end-to-end sobre partes críticas del sistema."
           ],
           "responsibilities": [
-            "Hacer análisis de datos: Leer los números, encontrar patrones relevantes y traducirlos en insights claros y accionables",
-            "Iterar en el desarrollo de agentes: Ajustar prompts, refinar razonamientos, testear mejoras, correr evaluaciones y ayudar a que los agentes respondan cada día mejor",
-            "Diseñar y desarrollar herramientas internas creativas: Crear utilidades y frameworks livianos que impulsen nuestro trabajo con data: automatizar workflows investigativos, acelerar la detección de patrones o diseñar nuevas formas de interactuar con la información",
-            "Ayudar a dar forma al producto: Trabajar con el equipo de ingeniería en features de producto y con el equipo comercial en entender necesidades de clientes y ajustar nuestros sistemas de AI para resolverlas de la mejor manera",
-            "Construir y mantener data pipelines: Conectar fuentes, modelar tablas, asegurar calidad de datos y alimentar a nuestros agentes con información limpia y estructurada"
+            "Diseñar, construir y operar servicios core de la platforma que soportan nuestros flujos de AI/LLM",
+            "Desarrollar y correr sistemas LLM-based (por ejemplo text-to-SQL, reasoning agents, planners), con foco en confiabilidad, performance y costos",
+            "Construir y mantener servicios backend y APIs que orquestan pipelines complejos y multi-step",
+            "Trabajar hands-on con infra basada en Kubernetes, incluyendo deployments, scaling y debugging en producción",
+            "Contribuir a workflows de DevOps y MLOps: CI/CD, environments, monitoring, logging y buenas prácticas operativas",
+            "Participar en decisiones de arquitectura alrededor de observabilidad, failure handling, evaluación y trade-offs del sistema",
+            "Colaborar de forma directa con founders y producto para transformar problemas reales de negocio en soluciones técnicas robustas"
           ],
           "requirements": [
-            "Formación analítica muy sólida. Muchas personas en este equipo vienen de ingeniería, economía, planificación o roles fuertemente orientados a data",
-            "Sos una persona muy curiosa que se auto-enseña cuando hace falta. En la frontera del Gen AI esto pasa seguido: para resolver un problema hay que aprender algo nuevo",
-            "Tenés facilidad para desarmar problemas y, cuando ves algo que podría funcionar mejor, intentás mejorarlo",
-            "Sos un early adopter de AI (ya seas usuario de ChatGPT, Claude o Grok) y la usás con frecuencia… idealmente todos los días",
-            "Tenés un punto de vista sobre negocios. Quizás podrías haber ido a consultoría estratégica (o tal vez fuiste), pero al menos con algunas personas de tu entorno solés tener conversaciones sobre negocio",
-            "Vivís en Buenos Aires y podés venir a la oficina una vez por semana",
-            "Dominio de inglés y español"
+            "4+ años de experiencia como software engineer en backend, ML o sistemas data-intensive",
+            "Fuerte software engineering mindset, con experiencia comprobable llevando sistemas a producción y manteniéndolos en el tiempo",
+            "Muy buen manejo de Python y experiencia construyendo backend services (FastAPI o similar)",
+            "Experiencia práctica con Docker y Kubernetes en entornos reales",
+            "Conocimientos básicos a sólidos de DevOps: CI/CD, cloud environments, logging, monitoring y deployments",
+            "Experiencia trabajando con cloud platforms (AWS preferido)",
+            "Experiencia práctica con LLMs en contextos aplicados (text-to-SQL, RAG, agent-based systems, etc.)",
+            "Capacidad para razonar y manejar trade-offs (calidad vs latencia, costo vs performance, simplicidad vs flexibilidad)",
+            "Buen nivel de comunicación en inglés"
           ],
           "bonusPoints": [
-            "Experiencia con Python o SQL",
-            "Experiencia con AI/LLMs (prompting, evaluations, LangChain/LangGraph, etc.)",
-            "Experiencia en data engineering (modeling, ETL/ELT, data warehouse tools, etc.)"
+            "Experiencia con dbs de SQL, data platforms o vector dbs",
+            "Experiencia diseñando frameworks de evaluación para ML o LLM systems",
+            "Experiencia previa en early-stage startups o equipos de alto ownership"
           ],
           "benefits": [
-            "Compensación competitiva",
-            "Equity significativo — creemos en ownership compartido",
-            "Flexibilidad dentro de un modelo híbrido",
-            "La oportunidad de dar forma a un producto y a un sistema de AI desde cero",
-            "Una misión significativa: hacer que los datos sean útiles para las personas, no solo para analistas"
+            "Trabajar en una plataforma AI/LLM real en producción, no demos ni research projects",
+            "Alto nivel de ownership e impacto directo en el core tecnológico y el producto",
+            "Equity + salario competitivo",
+            "Camino de crecimiento acelerado hacia roles senior o de liderazgo a medida que el equipo escala",
+            "Modalidad híbrida en Buenos Aires"
           ],
           "quickInfo": {
             "location": "Buenos Aires (Híbrido)",
-            "department": "Decision Science"
+            "experience": "4+ años",
+            "department": "Engineering"
           }
         }
       ]

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -199,50 +199,53 @@
       },
       "openPositions": [
         {
-          "slug": "decision-scientist-data-ai",
-          "title": "Decision Science – Data & AI Implementation",
+          "slug": "software-engineer-ai-llm",
+          "title": "Software Engineer, AI/LLM Platform",
           "location": "Buenos Aires (Híbrido) • Full-time",
-          "applicationUrl": "https://forms.gle/grhyoFSdbetVZZvCA",
+          "applicationUrl": "https://forms.gle/vbuJnRVXUoShqc8M9",
           "aboutNivii": [
-            "Imagine que você é líder de uma área em uma grande empresa e é segunda-feira de manhã. Chegaram os resultados do mês passado e não são os que esperávamos... talvez as margens caíram, o estoque subiu, o talento está rotando mais rápido ou a qualidade do produto está sofrendo. O que aconteceu é algo que a maioria das empresas sabe encontrar, mas o porquê e o que fazer é muito mais difícil e lento. Você precisava de respostas profundas da sua data de maneira instantânea, mas sem elas você volta a depender apenas da intuição.",
-            "Na Nivii estamos repensando como as pessoas interagem com os dados de negócio. Nosso sistema de AI conversacional permite fazer perguntas em linguagem natural e receber respostas claras, acionáveis, instantâneas e visuais. Combinando language models, data orchestration e geração de gráficos em uma única interface, ajudamos as equipes a passar de dados a decisões mais rápido do que nunca. Não construímos um chatbot nem outro \"talk to your data\": construímos um thinking partner, uma evolução do consulting tradicional.",
-            "Nosso produto já está em produção, com usuários reais em toda LATAM e tração inicial de equipes que precisam de respostas, não dashboards. Somos uma equipe pequena, prática, baseada em Buenos Aires, apaixonada pela usabilidade, clareza e por ajudar as pessoas a raciocinar melhor com dados."
+            "Na Nivii.ai, estamos construindo uma nova forma de trabalhar com dados. Em vez de dashboards e BI tradicional, estamos criando uma AI-powered platform que permite fazer perguntas complexas em linguagem natural e obter respostas estruturadas, explicáveis e acionáveis.",
+            "Ao longo do último ano, passamos do conceito para produção: hoje contamos com um sistema multi-agent que já é utilizado em fluxos reais de tomada de decisão. Agora buscamos adicionar um(a) Software Engineer, AI/LLM Platform para nos ajudar a escalar, fortalecer e evoluir os sistemas core que fazem a plataforma funcionar."
           ],
           "aboutRole": [
-            "Buscamos alguém para se juntar à equipe de Decision Science. Somos a equipe que garante que nossos agentes retornem respostas realmente profundas e úteis. Para conseguir isso, precisamos garantir que tenham insumos limpos e confiáveis, caminhos de raciocínio bem desenhados e o contexto de negócio adequado.",
-            "É um papel híbrido: parte data, parte análise, parte experimentação com AI. Ideal para alguém que goste de variedade, prospere em ambientes early-stage e queira gerar um impacto material no nosso produto e no negócio dos nossos clientes."
+            "Este é um papel software-engineering-first, com AI e LLM como building blocks centrais. Você vai trabalhar muito próximo do produto e dos founders, com ownership end-to-end sobre partes críticas do sistema."
           ],
           "responsibilities": [
-            "Fazer análise de dados: Ler os números, encontrar padrões relevantes e traduzi-los em insights claros e acionáveis",
-            "Iterar no desenvolvimento de agentes: Ajustar prompts, refinar raciocínios, testar melhorias, rodar avaliações e ajudar os agentes a responderem cada dia melhor",
-            "Desenhar e desenvolver ferramentas internas criativas: Criar utilidades e frameworks leves que impulsionem nosso trabalho com data: automatizar workflows investigativos, acelerar a detecção de padrões ou desenhar novas formas de interagir com a informação",
-            "Ajudar a dar forma ao produto: Trabalhar com a equipe de engenharia em features de produto e com a equipe comercial em entender necessidades de clientes e ajustar nossos sistemas de AI para resolvê-las da melhor maneira",
-            "Construir e manter data pipelines: Conectar fontes, modelar tabelas, assegurar qualidade de dados e alimentar nossos agentes com informação limpa e estruturada"
+            "Projetar, construir e operar serviços core da platform que suportam nossos fluxos de AI/LLM",
+            "Desenvolver e rodar LLM-based systems (por exemplo text-to-SQL, reasoning agents, planners), com foco em confiabilidade, performance e custos",
+            "Construir e manter backend services e APIs que orquestram pipelines complexos e multi-step",
+            "Trabalhar hands-on com infra baseada em Kubernetes, incluindo deployments, scaling e debugging em produção",
+            "Contribuir para workflows de DevOps e MLOps: CI/CD, environments, monitoring, logging e boas práticas operacionais",
+            "Participar de decisões de arquitetura relacionadas a observability, failure handling, avaliação e trade-offs do sistema",
+            "Colaborar diretamente com founders e produto para transformar problemas reais de negócio em soluciones técnicas robustas"
           ],
           "requirements": [
-            "Formação analítica muito sólida. Muitas pessoas nesta equipe vêm de engenharia, economia, planejamento ou papéis fortemente orientados a data",
-            "Você é uma pessoa muito curiosa que se auto-ensina quando precisa. Na fronteira do Gen AI isso acontece frequentemente: para resolver um problema é preciso aprender algo novo",
-            "Você tem facilidade para desmontar problemas e, quando vê algo que poderia funcionar melhor, tenta melhorá-lo",
-            "Você é um early adopter de AI (seja usuário de ChatGPT, Claude ou Grok) e a usa com frequência... idealmente todos os dias",
-            "Você tem um ponto de vista sobre negócios. Talvez você poderia ter ido para consultoria estratégica (ou talvez foi), mas pelo menos com algumas pessoas do seu entorno você costuma ter conversas sobre negócio",
-            "Você mora em Buenos Aires e pode vir ao escritório uma vez por semana",
-            "Domínio de inglês e espanhol"
+            "4+ anos de experiência como software engineer em backend, ML ou sistemas data-intensive",
+            "Forte software engineering mindset, com experiência comprovada levando sistemas para produção e mantendo-os ao longo do tempo",
+            "Excelente domínio de Python e experiência construindo backend services (FastAPI ou similar)",
+            "Experiência prática com Docker e Kubernetes em ambientes reais",
+            "Conhecimentos básicos a sólidos de DevOps: CI/CD, cloud environments, logging, monitoring e deployments",
+            "Experiência trabalhando com cloud platforms (AWS é um diferencial)",
+            "Experiência prática com LLMs em contextos aplicados (text-to-SQL, RAG, agent-based systems, etc.)",
+            "Capacidade de raciocinar e gerenciar trade-offs (qualidade vs latência, custo vs performance, simplicidade vs flexibilidade)",
+            "Bom nível de comunicação em inglês"
           ],
           "bonusPoints": [
-            "Experiência com Python ou SQL",
-            "Experiência com AI/LLMs (prompting, evaluations, LangChain/LangGraph, etc.)",
-            "Experiência em data engineering (modeling, ETL/ELT, data warehouse tools, etc.)"
+            "Experiência com SQL databases, data platforms ou vector databases",
+            "Experiência desenhando frameworks de avaliação para ML ou LLM systems",
+            "Experiência prévia em early-stage startups ou equipes com alto ownership"
           ],
           "benefits": [
-            "Compensação competitiva",
-            "Equity significativo — acreditamos em ownership compartilhado",
-            "Flexibilidade dentro de um modelo híbrido",
-            "A oportunidade de dar forma a um produto e a um sistema de AI desde o início",
-            "Uma missão significativa: fazer com que os dados sejam úteis para as pessoas, não só para analistas"
+            "Trabalhar em uma AI/LLM platform real em produção, não demos ou research projects",
+            "Alto nível de ownership e impacto direto no core tecnológico e no produto",
+            "Equity + salário competitivo",
+            "Caminho de crescimento acelerado para posições senior ou de liderança à medida que o time cresce",
+            "Modelo de trabalho híbrido em Buenos Aires"
           ],
           "quickInfo": {
             "location": "Buenos Aires (Híbrido)",
-            "department": "Decision Science"
+            "experience": "4+ anos",
+            "department": "Engineering"
           }
         }
       ]

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -202,7 +202,7 @@
           "slug": "software-engineer-ai-llm",
           "title": "Software Engineer, AI/LLM Platform",
           "location": "Buenos Aires (Híbrido) • Full-time",
-          "applicationUrl": "https://forms.gle/vbuJnRVXUoShqc8M9",
+          "applicationUrl": "https://forms.gle/WVC4sHzKW2VfwALX9",
           "aboutNivii": [
             "Na Nivii.ai, estamos construindo uma nova forma de trabalhar com dados. Em vez de dashboards e BI tradicional, estamos criando uma AI-powered platform que permite fazer perguntas complexas em linguagem natural e obter respostas estruturadas, explicáveis e acionáveis.",
             "Ao longo do último ano, passamos do conceito para produção: hoje contamos com um sistema multi-agent que já é utilizado em fluxos reais de tomada de decisão. Agora buscamos adicionar um(a) Software Engineer, AI/LLM Platform para nos ajudar a escalar, fortalecer e evoluir os sistemas core que fazem a plataforma funcionar."


### PR DESCRIPTION
## Summary
- Reverts the previous careers swap (#22)
- Closes the "Decision Scientist – Data & AI Implementation" listing
- Reopens the "Software Engineer, AI/LLM Platform" position with its original Google Form (`vbuJnRVXUoShqc8M9`)
- Changes applied across all three locales: English, Spanish, Portuguese

## Changed files
- `messages/en.json`
- `messages/es.json`
- `messages/pt.json`

## Test plan
- [ ] Visit `/careers` — listing shows Software Engineer position
- [ ] Visit `/careers/software-engineer-ai-llm` — full job detail page renders
- [ ] Visit `/careers/decision-scientist-data-ai` — shows "Position Not Found"
- [ ] "Apply Now" opens the SWE Google Form in a new tab
- [ ] `/es/careers` and `/pt/careers` render translated content correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)