### PR TITLE
Add Business Operations Manager position

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -247,6 +247,51 @@
             "experience": "4+ years",
             "department": "Engineering"
           }
+        },
+        {
+          "slug": "business-operations-manager",
+          "title": "Business Operations Manager",
+          "location": "Buenos Aires (Hybrid) • Full-time",
+          "aboutNivii": [
+            "Imagine you are the leader of an area in a large company and it's monday morning. The results from last month have just come in and they are not what we were expecting... maybe margins are down, stock has gone up, talent is leaving faster or our products quality is suffering. What happened is something most companies know how to find, but why and what to do is much much harder and slower. You needed instant answers from deep within your data, but without them you keep using only your intuition.",
+            "At Nivii, we're rethinking how people interact with business data. Our conversational AI system lets users ask questions in natural language and receive clear, actionable answers—instantly and visually. By combining language models, data orchestration, and chart generation into a seamless interface, we help teams move from data to decisions faster than ever before. We haven't built a chatbot or another \"talk to your data\" — we've built a thinking partner, an evolution of consulting.",
+            "Our product is already live, serving real users across LATAM, with early traction from teams that need answers, not dashboards. We're a small, hands-on team based in Buenos Aires, passionate about usability, clarity, and helping people reason better with data."
+          ],
+          "aboutRole": [
+            "We're looking for a Business Operations Manager to work side by side with our CBO. This is the person who makes sure the engine runs — that clients are being served well, that internal teams are moving in sync, and that the operational and administrative backbone of the company holds up as we scale.",
+            "This is a hybrid role: part project management, part operations, part client success. Perfect for someone who thrives with variety, owns problems end-to-end, and gets satisfaction from seeing things actually get done."
+          ],
+          "responsibilities": [
+            "Keep projects on track: Coordinate internal teams to ensure client delivery happens on time and with quality. Track progress, flag blockers early, and make sure commitments turn into results.",
+            "Own the operational backbone: Manage client billing, coordinate with our legal and accounting firms, and keep the administrative side of the business running smoothly.",
+            "Drive client success: Be an active point of contact for clients throughout their projects — giving them visibility, handling escalations, and making sure their experience is seamless from kickoff to delivery.",
+            "Make things better: Spot process gaps and fix them. We're an early-stage company and there's always room to build smarter workflows."
+          ],
+          "requirements": [
+            "2 to 4 years of experience in operations, project management, or account management — ideally in a B2B services or consulting environment.",
+            "You're the kind of person who sees something broken and fixes it before being asked.",
+            "Strong communicator — equally comfortable sending a clear whatsapp message to an internal team and getting on a call with a client.",
+            "You can hold multiple balls in the air without dropping any, and you know how to prioritize when everything feels urgent.",
+            "Detail-oriented but never loses sight of the bigger picture.",
+            "Based in Buenos Aires, with availability for in-person collaboration."
+          ],
+          "bonusPoints": [
+            "Experience coordinating with legal or accounting firms.",
+            "Familiarity with billing processes and basic financial administration.",
+            "Advanced English."
+          ],
+          "benefits": [
+            "Competitive compensation.",
+            "A meaningful equity stake — shared ownership matters.",
+            "Flexibility within a hybrid model.",
+            "A front-row seat to how an AI company operates and scales.",
+            "Real ownership over a critical function from day one."
+          ],
+          "quickInfo": {
+            "location": "Buenos Aires (Hybrid)",
+            "experience": "2-4 years",
+            "department": "Operations"
+          }
         }
       ]
     }

--- a/messages/en.json
+++ b/messages/en.json
@@ -252,6 +252,7 @@
           "slug": "business-operations-manager",
           "title": "Business Operations Manager",
           "location": "Buenos Aires (Hybrid) • Full-time",
+          "applicationUrl": "https://forms.gle/BvHs3JQsnARc1ZJE6",
           "aboutNivii": [
             "Imagine you are the leader of an area in a large company and it's monday morning. The results from last month have just come in and they are not what we were expecting... maybe margins are down, stock has gone up, talent is leaving faster or our products quality is suffering. What happened is something most companies know how to find, but why and what to do is much much harder and slower. You needed instant answers from deep within your data, but without them you keep using only your intuition.",
             "At Nivii, we're rethinking how people interact with business data. Our conversational AI system lets users ask questions in natural language and receive clear, actionable answers—instantly and visually. By combining language models, data orchestration, and chart generation into a seamless interface, we help teams move from data to decisions faster than ever before. We haven't built a chatbot or another \"talk to your data\" — we've built a thinking partner, an evolution of consulting.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -252,6 +252,7 @@
           "slug": "business-operations-manager",
           "title": "Business Operations Manager",
           "location": "Buenos Aires (Híbrido) • Full-time",
+          "applicationUrl": "https://forms.gle/BvHs3JQsnARc1ZJE6",
           "aboutNivii": [
             "Imaginá que sos líder de un área en una gran compañía y es lunes a la mañana. Llegaron los resultados del mes pasado y no son los que esperábamos… tal vez bajaron los márgenes, subió el stock, el talento está rotando más rápido o la calidad del producto está sufriendo. Qué pasó es algo que la mayoría de las empresas sabe encontrar, pero el por qué y qué hacer es mucho más difícil y lento. Necesitabas respuestas profundas de tu data de manera instantánea, pero sin ellas volvés a depender solo de la intuición.",
             "En Nivii estamos repensando cómo las personas interactúan con los datos de negocio. Nuestro sistema de AI conversacional permite hacer preguntas en lenguaje natural y recibir respuestas claras, accionables, instantáneas y visuales. Combinando language models, data orchestration y generación de gráficos en una sola interfaz, ayudamos a los equipos a pasar de datos a decisiones más rápido que nunca. No construimos un chatbot ni otro \"talk to your data\": construimos un thinking partner, una evolución del consulting tradicional.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -247,6 +247,51 @@
             "experience": "4+ años",
             "department": "Engineering"
           }
+        },
+        {
+          "slug": "business-operations-manager",
+          "title": "Business Operations Manager",
+          "location": "Buenos Aires (Híbrido) • Full-time",
+          "aboutNivii": [
+            "Imaginá que sos líder de un área en una gran compañía y es lunes a la mañana. Llegaron los resultados del mes pasado y no son los que esperábamos… tal vez bajaron los márgenes, subió el stock, el talento está rotando más rápido o la calidad del producto está sufriendo. Qué pasó es algo que la mayoría de las empresas sabe encontrar, pero el por qué y qué hacer es mucho más difícil y lento. Necesitabas respuestas profundas de tu data de manera instantánea, pero sin ellas volvés a depender solo de la intuición.",
+            "En Nivii estamos repensando cómo las personas interactúan con los datos de negocio. Nuestro sistema de AI conversacional permite hacer preguntas en lenguaje natural y recibir respuestas claras, accionables, instantáneas y visuales. Combinando language models, data orchestration y generación de gráficos en una sola interfaz, ayudamos a los equipos a pasar de datos a decisiones más rápido que nunca. No construimos un chatbot ni otro \"talk to your data\": construimos un thinking partner, una evolución del consulting tradicional.",
+            "Nuestro producto ya está en producción, con usuarios reales en toda LATAM y tracción temprana de equipos que necesitan respuestas, no dashboards. Somos un equipo pequeño, práctico, basado en Buenos Aires, apasionado por la usabilidad, la claridad y por ayudar a las personas a razonar mejor con datos."
+          ],
+          "aboutRole": [
+            "Buscamos un/a Business Operations Manager para trabajar codo a codo con nuestro CBO. Es la persona que se asegura de que el motor funcione — que los clientes estén bien atendidos, que los equipos internos vayan sincronizados y que el backbone operativo y administrativo de la compañía aguante a medida que escalamos.",
+            "Es un rol híbrido: parte project management, parte operations, parte client success. Ideal para alguien que disfruta la variedad, toma ownership end-to-end de los problemas y se satisface viendo las cosas realmente hechas."
+          ],
+          "responsibilities": [
+            "Mantener los proyectos on track: Coordinar equipos internos para asegurar que la entrega al cliente suceda a tiempo y con calidad. Trackear el progreso, detectar blockers temprano y asegurarte de que los compromisos se transformen en resultados.",
+            "Ser dueño/a del backbone operativo: Gestionar la facturación a clientes, coordinar con nuestros estudios legales y contables y mantener el costado administrativo del negocio corriendo sin fricción.",
+            "Impulsar el client success: Ser un punto de contacto activo con los clientes durante sus proyectos — dándoles visibilidad, manejando escalaciones y asegurándote de que su experiencia sea seamless desde el kickoff hasta la entrega.",
+            "Mejorar las cosas: Detectar gaps en los procesos y resolverlos. Somos una compañía early-stage y siempre hay espacio para construir workflows más inteligentes."
+          ],
+          "requirements": [
+            "2 a 4 años de experiencia en operations, project management o account management — idealmente en un entorno B2B de servicios o consulting.",
+            "Sos del tipo de persona que cuando ve algo roto lo arregla antes de que se lo pidan.",
+            "Excelente comunicador/a — te sentís igual de cómodo/a mandando un mensaje claro por WhatsApp a un equipo interno y subiéndote a una call con un cliente.",
+            "Podés tener varias pelotas en el aire sin que se te caiga ninguna, y sabés priorizar cuando todo parece urgente.",
+            "Detallista, pero sin perder de vista el panorama general.",
+            "Basado/a en Buenos Aires, con disponibilidad para colaboración presencial."
+          ],
+          "bonusPoints": [
+            "Experiencia coordinando con estudios legales o contables.",
+            "Familiaridad con procesos de facturación y administración financiera básica.",
+            "Inglés avanzado."
+          ],
+          "benefits": [
+            "Compensación competitiva.",
+            "Un equity significativo — el ownership compartido importa.",
+            "Flexibilidad dentro de un modelo híbrido.",
+            "Un asiento en primera fila para ver cómo opera y escala una compañía de AI.",
+            "Ownership real sobre una función crítica desde el día uno."
+          ],
+          "quickInfo": {
+            "location": "Buenos Aires (Híbrido)",
+            "experience": "2-4 años",
+            "department": "Operations"
+          }
         }
       ]
     }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -252,6 +252,7 @@
           "slug": "business-operations-manager",
           "title": "Business Operations Manager",
           "location": "Buenos Aires (Híbrido) • Full-time",
+          "applicationUrl": "https://forms.gle/BvHs3JQsnARc1ZJE6",
           "aboutNivii": [
             "Imagine que você é líder de uma área em uma grande empresa e é segunda-feira de manhã. Chegaram os resultados do mês passado e não são os que esperávamos... talvez as margens caíram, o estoque subiu, o talento está rotando mais rápido ou a qualidade do produto está sofrendo. O que aconteceu é algo que a maioria das empresas sabe encontrar, mas o porquê e o que fazer é muito mais difícil e lento. Você precisava de respostas profundas da sua data de maneira instantânea, mas sem elas você volta a depender apenas da intuição.",
             "Na Nivii estamos repensando como as pessoas interagem com os dados de negócio. Nosso sistema de AI conversacional permite fazer perguntas em linguagem natural e receber respostas claras, acionáveis, instantâneas e visuais. Combinando language models, data orchestration e geração de gráficos em uma única interface, ajudamos as equipes a passar de dados a decisões mais rápido do que nunca. Não construímos um chatbot nem outro \"talk to your data\": construímos um thinking partner, uma evolução do consulting tradicional.",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -247,6 +247,51 @@
             "experience": "4+ anos",
             "department": "Engineering"
           }
+        },
+        {
+          "slug": "business-operations-manager",
+          "title": "Business Operations Manager",
+          "location": "Buenos Aires (Híbrido) • Full-time",
+          "aboutNivii": [
+            "Imagine que você é líder de uma área em uma grande empresa e é segunda-feira de manhã. Chegaram os resultados do mês passado e não são os que esperávamos... talvez as margens caíram, o estoque subiu, o talento está rotando mais rápido ou a qualidade do produto está sofrendo. O que aconteceu é algo que a maioria das empresas sabe encontrar, mas o porquê e o que fazer é muito mais difícil e lento. Você precisava de respostas profundas da sua data de maneira instantânea, mas sem elas você volta a depender apenas da intuição.",
+            "Na Nivii estamos repensando como as pessoas interagem com os dados de negócio. Nosso sistema de AI conversacional permite fazer perguntas em linguagem natural e receber respostas claras, acionáveis, instantâneas e visuais. Combinando language models, data orchestration e geração de gráficos em uma única interface, ajudamos as equipes a passar de dados a decisões mais rápido do que nunca. Não construímos um chatbot nem outro \"talk to your data\": construímos um thinking partner, uma evolução do consulting tradicional.",
+            "Nosso produto já está em produção, com usuários reais em toda LATAM e tração inicial de equipes que precisam de respostas, não dashboards. Somos uma equipe pequena, prática, baseada em Buenos Aires, apaixonada pela usabilidade, clareza e por ajudar as pessoas a raciocinar melhor com dados."
+          ],
+          "aboutRole": [
+            "Buscamos um(a) Business Operations Manager para trabalhar lado a lado com nosso CBO. É a pessoa que garante que o motor funcione — que os clientes estejam bem atendidos, que as equipes internas estejam sincronizadas e que o backbone operacional e administrativo da empresa aguente à medida que escalamos.",
+            "É um papel híbrido: parte project management, parte operations, parte client success. Ideal para alguém que gosta de variedade, assume ownership end-to-end dos problemas e se satisfaz ao ver as coisas realmente serem feitas."
+          ],
+          "responsibilities": [
+            "Manter os projetos on track: Coordenar equipes internas para garantir que a entrega ao cliente aconteça no prazo e com qualidade. Acompanhar o progresso, sinalizar blockers cedo e garantir que os compromissos se transformem em resultados.",
+            "Ser dono(a) do backbone operacional: Gerenciar o faturamento dos clientes, coordenar com nossos escritórios jurídicos e contábeis e manter o lado administrativo do negócio rodando sem fricção.",
+            "Impulsionar o client success: Ser um ponto de contato ativo com os clientes durante seus projetos — dando visibilidade, lidando com escalações e garantindo que a experiência seja seamless do kickoff à entrega.",
+            "Melhorar as coisas: Identificar gaps nos processos e resolvê-los. Somos uma empresa early-stage e sempre há espaço para construir workflows mais inteligentes."
+          ],
+          "requirements": [
+            "2 a 4 anos de experiência em operations, project management ou account management — idealmente em um ambiente B2B de serviços ou consulting.",
+            "Você é o tipo de pessoa que quando vê algo quebrado, conserta antes de alguém pedir.",
+            "Excelente comunicador(a) — igualmente confortável enviando uma mensagem clara por WhatsApp para uma equipe interna e entrando em uma call com um cliente.",
+            "Consegue segurar várias bolas no ar sem deixar nenhuma cair e sabe priorizar quando tudo parece urgente.",
+            "Atento(a) aos detalhes, mas sem perder de vista o panorama geral.",
+            "Baseado(a) em Buenos Aires, com disponibilidade para colaboração presencial."
+          ],
+          "bonusPoints": [
+            "Experiência coordenando com escritórios jurídicos ou contábeis.",
+            "Familiaridade com processos de faturamento e administração financeira básica.",
+            "Inglês avançado."
+          ],
+          "benefits": [
+            "Compensação competitiva.",
+            "Equity significativo — o ownership compartilhado importa.",
+            "Flexibilidade dentro de um modelo híbrido.",
+            "Um assento na primeira fila para ver como opera e escala uma empresa de AI.",
+            "Ownership real sobre uma função crítica desde o primeiro dia."
+          ],
+          "quickInfo": {
+            "location": "Buenos Aires (Híbrido)",
+            "experience": "2-4 anos",
+            "department": "Operations"
+          }
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Adds a new "Business Operations Manager" position alongside the existing Software Engineer listing
- Translations provided for English, Spanish (Rioplatense), and Portuguese
- Business/tech terms kept in English where no well-used translation exists: project management, operations, client success, kickoff, blockers, backbone, workflows, ownership, equity, early-stage, B2B, WhatsApp, call, CBO, AI, LATAM, etc.

## Position details
- **Title**: Business Operations Manager
- **Department**: Operations
- **Experience**: 2-4 years
- **Location**: Buenos Aires (Hybrid) — Full-time
- **Slug**: `business-operations-manager`

## Heads up — application URL
No `applicationUrl` was provided, so "Apply Now" will fall back to `mailto:careers@nivii.ai?subject=Application for Business Operations Manager`. If you want to use a Google Form instead, let me know the URL and I'll add it.

## Changed files
- `messages/en.json`
- `messages/es.json`
- `messages/pt.json`

## Test plan
- [ ] Visit `/careers` — listing shows both positions
- [ ] Visit `/careers/business-operations-manager` — detail page renders correctly
- [ ] Quick Info sidebar shows Location, Experience (2-4 years), Department (Operations)
- [ ] Apply button triggers mailto fallback (until a form URL is added)
- [ ] `/es/careers/business-operations-manager` and `/pt/careers/business-operations-manager` render translations correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
