### PR TITLE
Close Software Engineer position

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -197,58 +197,7 @@
         "notFoundPositionTitle": "Ooops! Position Not Found",
         "notFoundPositionDescription": "The position you are looking for does not exist or has been filled. Please check our open positions for other opportunities."
       },
-      "openPositions": [
-        {
-          "slug": "software-engineer-ai-llm",
-          "title": "Software Engineer, AI/LLM Platform",
-          "location": "Buenos Aires (Hybrid) • Full-time",
-          "applicationUrl": "https://forms.gle/WVC4sHzKW2VfwALX9",
-          "aboutNivii": [
-            "At Nivii.ai, we're building a new way for teams to work with data. Instead of dashboards and traditional BI, we're creating an AI-powered platform that allows users to ask complex business questions in natural language and receive structured, explainable, and actionable answers.",
-            "Over the past year, we've moved from concept to production: a multi-agent system that is already being used in real decision-making workflows. We're now looking for a Software Engineer, AI/LLM Platform to help us scale, harden, and evolve the core systems that power this platform."
-          ],
-          "aboutRole": [
-            "This role is software-engineering-first, with AI and LLMs as core building blocks. You'll work very close to the product and the founders, owning critical parts of the platform end-to-end."
-          ],
-          "responsibilities": [
-            "Design, build, and own core platform services that power our AI/LLM workflows",
-            "Develop and operate LLM-based systems (e.g. text-to-SQL, reasoning agents, planners), with a strong focus on reliability, performance, and cost",
-            "Build and maintain backend services and APIs that orchestrate complex, multi-step AI pipelines",
-            "Work hands-on with Kubernetes-based infrastructure, including deployments, scaling, and debugging production issues",
-            "Contribute to DevOps and MLOps workflows: CI/CD, environments, monitoring, logging, and operational best practices",
-            "Collaborate on architectural decisions around observability, failure handling, evaluation, and system trade-offs",
-            "Work closely with founders and product to translate real business problems into robust technical solutions"
-          ],
-          "requirements": [
-            "4+ years of experience as a software engineer in backend, ML, or data-intensive systems",
-            "Strong software engineering mindset with proven experience shipping and maintaining production systems",
-            "Excellent Python skills and experience building backend services (FastAPI or similar)",
-            "Solid hands-on experience with Docker and Kubernetes in real-world environments",
-            "Basic to solid DevOps knowledge: CI/CD pipelines, cloud environments, logging, monitoring, and deployments",
-            "Experience with cloud platforms (AWS preferred)",
-            "Practical experience working with LLMs in applied settings (text-to-SQL, RAG, agent-based systems, or similar)",
-            "Ability to reason about and manage trade-offs (quality vs latency, cost vs performance, simplicity vs flexibility)",
-            "Strong communication skills in English"
-          ],
-          "bonusPoints": [
-            "Experience with SQL databases, data platforms, or vector databases",
-            "Experience designing evaluation frameworks for ML or LLM systems",
-            "Previous experience in early-stage startups or high-ownership teams"
-          ],
-          "benefits": [
-            "Work on a real AI/LLM platform in production, not demos or research projects",
-            "High ownership and direct impact on the core technology and product direction",
-            "Equity + competitive salary",
-            "Fast growth path into senior or leadership responsibilities as the team scales",
-            "Hybrid work model based in Buenos Aires"
-          ],
-          "quickInfo": {
-            "location": "Buenos Aires (Hybrid)",
-            "experience": "4+ years",
-            "department": "Engineering"
-          }
-        }
-      ]
+      "openPositions": []
     }
   },
   "footer": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -197,58 +197,7 @@
         "notFoundPositionTitle": "¡Ups! Puesto No Encontrado",
         "notFoundPositionDescription": "El puesto que estás buscando no existe o ya ha sido cubierto. Por favor, revisa nuestros puestos abiertos para otras oportunidades."
       },
-      "openPositions": [
-        {
-          "slug": "software-engineer-ai-llm",
-          "title": "Software Engineer, AI/LLM Platform",
-          "location": "Buenos Aires (Híbrido) • Full-time",
-          "applicationUrl": "https://forms.gle/WVC4sHzKW2VfwALX9",
-          "aboutNivii": [
-            "En Nivii.ai estamos construyendo una nueva forma de trabajar con datos. En lugar de dashboards y BI tradicional, estamos creando una AI-powered platform que permite hacer preguntas complejas en lenguaje natural y obtener respuestas estructuradas, explicables y accionables.",
-            "Durante el último año pasamos de concepto a producción: hoy contamos con un sistema multi-agent que ya se utiliza en flujos reales de toma de decisiones. Ahora buscamos sumar un/a Software Engineer, AI/LLM Platform para ayudarnos a escalar, robustecer y evolucionar los sistemas core que hacen funcionar la plataforma."
-          ],
-          "aboutRole": [
-            "Este rol es software-engineering-first, con AI y LLM como building blocks centrales. Vas a trabajar muy cerca del producto y de los founders, con ownership end-to-end sobre partes críticas del sistema."
-          ],
-          "responsibilities": [
-            "Diseñar, construir y operar servicios core de la platforma que soportan nuestros flujos de AI/LLM",
-            "Desarrollar y correr sistemas LLM-based (por ejemplo text-to-SQL, reasoning agents, planners), con foco en confiabilidad, performance y costos",
-            "Construir y mantener servicios backend y APIs que orquestan pipelines complejos y multi-step",
-            "Trabajar hands-on con infra basada en Kubernetes, incluyendo deployments, scaling y debugging en producción",
-            "Contribuir a workflows de DevOps y MLOps: CI/CD, environments, monitoring, logging y buenas prácticas operativas",
-            "Participar en decisiones de arquitectura alrededor de observabilidad, failure handling, evaluación y trade-offs del sistema",
-            "Colaborar de forma directa con founders y producto para transformar problemas reales de negocio en soluciones técnicas robustas"
-          ],
-          "requirements": [
-            "4+ años de experiencia como software engineer en backend, ML o sistemas data-intensive",
-            "Fuerte software engineering mindset, con experiencia comprobable llevando sistemas a producción y manteniéndolos en el tiempo",
-            "Muy buen manejo de Python y experiencia construyendo backend services (FastAPI o similar)",
-            "Experiencia práctica con Docker y Kubernetes en entornos reales",
-            "Conocimientos básicos a sólidos de DevOps: CI/CD, cloud environments, logging, monitoring y deployments",
-            "Experiencia trabajando con cloud platforms (AWS preferido)",
-            "Experiencia práctica con LLMs en contextos aplicados (text-to-SQL, RAG, agent-based systems, etc.)",
-            "Capacidad para razonar y manejar trade-offs (calidad vs latencia, costo vs performance, simplicidad vs flexibilidad)",
-            "Buen nivel de comunicación en inglés"
-          ],
-          "bonusPoints": [
-            "Experiencia con dbs de SQL, data platforms o vector dbs",
-            "Experiencia diseñando frameworks de evaluación para ML o LLM systems",
-            "Experiencia previa en early-stage startups o equipos de alto ownership"
-          ],
-          "benefits": [
-            "Trabajar en una plataforma AI/LLM real en producción, no demos ni research projects",
-            "Alto nivel de ownership e impacto directo en el core tecnológico y el producto",
-            "Equity + salario competitivo",
-            "Camino de crecimiento acelerado hacia roles senior o de liderazgo a medida que el equipo escala",
-            "Modalidad híbrida en Buenos Aires"
-          ],
-          "quickInfo": {
-            "location": "Buenos Aires (Híbrido)",
-            "experience": "4+ años",
-            "department": "Engineering"
-          }
-        }
-      ]
+      "openPositions": []
     }
   },
   "footer": {

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -197,58 +197,7 @@
         "notFoundPositionTitle": "Ops! Vaga Não Encontrada",
         "notFoundPositionDescription": "A vaga que você procura não existe ou já foi preenchida. Confira nossas vagas abertas para outras oportunidades."
       },
-      "openPositions": [
-        {
-          "slug": "software-engineer-ai-llm",
-          "title": "Software Engineer, AI/LLM Platform",
-          "location": "Buenos Aires (Híbrido) • Full-time",
-          "applicationUrl": "https://forms.gle/WVC4sHzKW2VfwALX9",
-          "aboutNivii": [
-            "Na Nivii.ai, estamos construindo uma nova forma de trabalhar com dados. Em vez de dashboards e BI tradicional, estamos criando uma AI-powered platform que permite fazer perguntas complexas em linguagem natural e obter respostas estruturadas, explicáveis e acionáveis.",
-            "Ao longo do último ano, passamos do conceito para produção: hoje contamos com um sistema multi-agent que já é utilizado em fluxos reais de tomada de decisão. Agora buscamos adicionar um(a) Software Engineer, AI/LLM Platform para nos ajudar a escalar, fortalecer e evoluir os sistemas core que fazem a plataforma funcionar."
-          ],
-          "aboutRole": [
-            "Este é um papel software-engineering-first, com AI e LLM como building blocks centrais. Você vai trabalhar muito próximo do produto e dos founders, com ownership end-to-end sobre partes críticas do sistema."
-          ],
-          "responsibilities": [
-            "Projetar, construir e operar serviços core da platform que suportam nossos fluxos de AI/LLM",
-            "Desenvolver e rodar LLM-based systems (por exemplo text-to-SQL, reasoning agents, planners), com foco em confiabilidade, performance e custos",
-            "Construir e manter backend services e APIs que orquestram pipelines complexos e multi-step",
-            "Trabalhar hands-on com infra baseada em Kubernetes, incluindo deployments, scaling e debugging em produção",
-            "Contribuir para workflows de DevOps e MLOps: CI/CD, environments, monitoring, logging e boas práticas operacionais",
-            "Participar de decisões de arquitetura relacionadas a observability, failure handling, avaliação e trade-offs do sistema",
-            "Colaborar diretamente com founders e produto para transformar problemas reais de negócio em soluciones técnicas robustas"
-          ],
-          "requirements": [
-            "4+ anos de experiência como software engineer em backend, ML ou sistemas data-intensive",
-            "Forte software engineering mindset, com experiência comprovada levando sistemas para produção e mantendo-os ao longo do tempo",
-            "Excelente domínio de Python e experiência construindo backend services (FastAPI ou similar)",
-            "Experiência prática com Docker e Kubernetes em ambientes reais",
-            "Conhecimentos básicos a sólidos de DevOps: CI/CD, cloud environments, logging, monitoring e deployments",
-            "Experiência trabalhando com cloud platforms (AWS é um diferencial)",
-            "Experiência prática com LLMs em contextos aplicados (text-to-SQL, RAG, agent-based systems, etc.)",
-            "Capacidade de raciocinar e gerenciar trade-offs (qualidade vs latência, custo vs performance, simplicidade vs flexibilidade)",
-            "Bom nível de comunicação em inglês"
-          ],
-          "bonusPoints": [
-            "Experiência com SQL databases, data platforms ou vector databases",
-            "Experiência desenhando frameworks de avaliação para ML ou LLM systems",
-            "Experiência prévia em early-stage startups ou equipes com alto ownership"
-          ],
-          "benefits": [
-            "Trabalhar em uma AI/LLM platform real em produção, não demos ou research projects",
-            "Alto nível de ownership e impacto direto no core tecnológico e no produto",
-            "Equity + salário competitivo",
-            "Caminho de crescimento acelerado para posições senior ou de liderança à medida que o time cresce",
-            "Modelo de trabalho híbrido em Buenos Aires"
-          ],
-          "quickInfo": {
-            "location": "Buenos Aires (Híbrido)",
-            "experience": "4+ anos",
-            "department": "Engineering"
-          }
-        }
-      ]
+      "openPositions": []
     }
   },
   "footer": {


### PR DESCRIPTION
## Summary
- Removes the Software Engineer, AI/LLM Platform position from `openPositions` in en/es/pt message bundles
- Careers page will now render the existing `noPositions` empty-state message

## Test plan
- [ ] Careers page shows the "no open positions" message in en, es, pt
- [ ] The /careers/software-engineer-ai-llm route hits the not-found state
- [ ] No console errors from missing translation keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)
