### PR TITLE
feat: reopen Decision Scientist position

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -197,7 +197,55 @@
         "notFoundPositionTitle": "Ooops! Position Not Found",
         "notFoundPositionDescription": "The position you are looking for does not exist or has been filled. Please check our open positions for other opportunities."
       },
-      "openPositions": []
+      "openPositions": [
+        {
+          "slug": "decision-scientist-data-ai",
+          "title": "Decision Scientist – Data & AI Implementation",
+          "location": "Buenos Aires (Hybrid) • Full-time",
+          "applicationUrl": "https://forms.gle/grhyoFSdbetVZZvCA",
+          "aboutNivii": [
+            "Imagine you are the leader of an area in a large company and it's monday morning. The results from last month have just come in and they are not what we were expecting... maybe margins are down, stock has gone up, talent is leaving faster or our products quality is suffering. What happened is something most companies know how to find, but why and what to do is much much harder and slower. You needed instant answers from deep within your data, but without them you keep using only your intuition.",
+            "At Nivii, we're rethinking how people interact with business data. Our conversational AI system lets users ask questions in natural language and receive clear, actionable answers—instantly and visually. By combining large language models, data orchestration, and chart generation into a seamless interface, we help teams move from data to decisions faster than ever before. We haven't built a chatbot or another \"talk to your data\" — we've built a thinking partner, an evolution of consulting.",
+            "Our product is already live, serving real users across LATAM, with early traction from teams that need answers, not dashboards. We're a small, hands-on team based in Buenos Aires, passionate about usability, clarity, and helping people reason better with data."
+          ],
+          "aboutRole": [
+            "We're looking for someone to join Nivii's Decision Science team. We are the team that makes sure our agents give back really insightful answers. To do that we usually need to make sure they have clean, reliable inputs, sharp reasoning pathways and the right business context.",
+            "This is a hybrid role: part data, part analysis, part AI experimentation. Perfect for someone who loves variety and thrives in early-stage environments but who loves being able to have a material impact in our product and our client's business."
+          ],
+          "responsibilities": [
+            "Conduct data analysis: Look at the numbers, find meaningful patterns, and translate them into clear, actionable insights for the business",
+            "Iterate on agent development: Adjust prompts, refine reasoning, test improvements, run evaluations, and help our agents answer each day a little better",
+            "Design and develop creative internal tools: Build inventive, lightweight utilities and frameworks that push our data analysis forward—whether that's automating investigative workflows, surfacing insights faster, or crafting new ways for the team to interact with data",
+            "Help shape the product: Work closely with Engineering on product features and with our Commercial team to understand client needs and tune our AI systems to solve them effectively",
+            "Build and maintain data pipelines: Connect sources, model tables, ensure data quality, and keep our agents well-fed with clean, structured information"
+          ],
+          "requirements": [
+            "Really strong analytical background. Often people in this area have engineering, economist, planning or other data-driven roles",
+            "You are a very curious person who self teaches whenever is needed. In the cutting edge of Gen AI we often find that to solve a problem we need to learn new things",
+            "You tend to excel at breaking down problems and when you see something we could do better you try to fix it",
+            "You are an early adopter of AI (doesn't matter if you like ChatGPT, Claude or Gemini) and you use it frequently... hopefully every day",
+            "You have a point of view about business. Maybe you could have gone into strategy consulting (maybe you did!) but at least with some group of people in your life you tend to have conversations about business",
+            "You are based in Buenos Aires, with availability for in-person collaboration once a week",
+            "Fluent in English and Spanish"
+          ],
+          "bonusPoints": [
+            "Experience with Python or SQL",
+            "Experience with AI/LLMs (prompting, evaluations, LangChain/LangGraph, etc.)",
+            "Experience in data engineering (modeling, ETL/ELT, warehouse tools)"
+          ],
+          "benefits": [
+            "Competitive compensation",
+            "A meaningful equity stake—shared ownership matters",
+            "Flexibility within a hybrid model",
+            "The chance to shape a product and an AI system from the ground up",
+            "A meaningful mission: making data useful to humans, not just analysts"
+          ],
+          "quickInfo": {
+            "location": "Buenos Aires (Hybrid)",
+            "department": "Decision Science"
+          }
+        }
+      ]
     }
   },
   "footer": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -202,7 +202,7 @@
           "slug": "decision-scientist-data-ai",
           "title": "Decision Scientist – Data & AI Implementation",
           "location": "Buenos Aires (Hybrid) • Full-time",
-          "applicationUrl": "https://forms.gle/grhyoFSdbetVZZvCA",
+          "applicationUrl": "https://forms.gle/FPadA7xBrfcKYMgM6",
           "aboutNivii": [
             "Imagine you are the leader of an area in a large company and it's monday morning. The results from last month have just come in and they are not what we were expecting... maybe margins are down, stock has gone up, talent is leaving faster or our products quality is suffering. What happened is something most companies know how to find, but why and what to do is much much harder and slower. You needed instant answers from deep within your data, but without them you keep using only your intuition.",
             "At Nivii, we're rethinking how people interact with business data. Our conversational AI system lets users ask questions in natural language and receive clear, actionable answers—instantly and visually. By combining large language models, data orchestration, and chart generation into a seamless interface, we help teams move from data to decisions faster than ever before. We haven't built a chatbot or another \"talk to your data\" — we've built a thinking partner, an evolution of consulting.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -197,7 +197,55 @@
         "notFoundPositionTitle": "¡Ups! Puesto No Encontrado",
         "notFoundPositionDescription": "El puesto que estás buscando no existe o ya ha sido cubierto. Por favor, revisa nuestros puestos abiertos para otras oportunidades."
       },
-      "openPositions": []
+      "openPositions": [
+        {
+          "slug": "decision-scientist-data-ai",
+          "title": "Decision Scientist – Data & AI Implementation",
+          "location": "Buenos Aires (Híbrido) • Full-time",
+          "applicationUrl": "https://forms.gle/grhyoFSdbetVZZvCA",
+          "aboutNivii": [
+            "Imaginá que sos líder de un área en una gran compañía y es lunes a la mañana. Llegaron los resultados del mes pasado y no son los que esperábamos… tal vez bajaron los márgenes, subió el stock, el talento está rotando más rápido o la calidad del producto está sufriendo. Qué pasó es algo que la mayoría de las empresas sabe encontrar, pero el por qué y qué hacer es mucho más difícil y lento. Necesitabas respuestas profundas de tu data de manera instantánea, pero sin ellas volvés a depender solo de la intuición.",
+            "En Nivii estamos repensando cómo las personas interactúan con los datos de negocio. Nuestro sistema de AI conversacional permite hacer preguntas en lenguaje natural y recibir respuestas claras, accionables, instantáneas y visuales. Combinando large language models, data orchestration y generación de gráficos en una sola interfaz, ayudamos a los equipos a pasar de datos a decisiones más rápido que nunca. No construimos un chatbot ni otro \"talk to your data\": construimos un thinking partner, una evolución del consulting tradicional.",
+            "Nuestro producto ya está en producción, con usuarios reales en toda LATAM y tracción temprana de equipos que necesitan respuestas, no dashboards. Somos un equipo pequeño, práctico, basado en Buenos Aires, apasionado por la usabilidad, la claridad y por ayudar a las personas a razonar mejor con datos."
+          ],
+          "aboutRole": [
+            "Buscamos a alguien para sumarse al equipo de Decision Science. Somos el equipo que se asegura de que nuestros agentes devuelvan respuestas realmente profundas y útiles. Para lograrlo, necesitamos garantizar que tengan insumos limpios y confiables, caminos de razonamiento bien diseñados y el contexto de negocio adecuado.",
+            "Es un rol híbrido: parte data, parte análisis, parte experimentación con AI. Ideal para alguien que disfrute la variedad, prospere en entornos early-stage y quiera generar un impacto material en nuestro producto y en el negocio de nuestros clientes."
+          ],
+          "responsibilities": [
+            "Hacer análisis de datos: Leer los números, encontrar patrones relevantes y traducirlos en insights claros y accionables",
+            "Iterar en el desarrollo de agentes: Ajustar prompts, refinar razonamientos, testear mejoras, correr evaluaciones y ayudar a que los agentes respondan cada día mejor",
+            "Diseñar y desarrollar herramientas internas creativas: Crear utilidades y frameworks livianos que impulsen nuestro trabajo con data: automatizar workflows investigativos, acelerar la detección de patrones o diseñar nuevas formas de interactuar con la información",
+            "Ayudar a dar forma al producto: Trabajar con el equipo de ingeniería en features de producto y con el equipo comercial en entender necesidades de clientes y ajustar nuestros sistemas de AI para resolverlas de la mejor manera",
+            "Construir y mantener data pipelines: Conectar fuentes, modelar tablas, asegurar calidad de datos y alimentar a nuestros agentes con información limpia y estructurada"
+          ],
+          "requirements": [
+            "Formación analítica muy sólida. Muchas personas en este equipo vienen de ingeniería, economía, planificación o roles fuertemente orientados a data",
+            "Sos una persona muy curiosa que se auto-enseña cuando hace falta. En la frontera del Gen AI esto pasa seguido: para resolver un problema hay que aprender algo nuevo",
+            "Tenés facilidad para desarmar problemas y, cuando ves algo que podría funcionar mejor, intentás mejorarlo",
+            "Sos un early adopter de AI (ya seas usuario de ChatGPT, Claude o Gemini) y la usás con frecuencia… idealmente todos los días",
+            "Tenés un punto de vista sobre negocios. Quizás podrías haber ido a consultoría estratégica (o tal vez fuiste), pero al menos con algunas personas de tu entorno solés tener conversaciones sobre negocio",
+            "Vivís en Buenos Aires y podés venir a la oficina una vez por semana",
+            "Dominio de inglés y español"
+          ],
+          "bonusPoints": [
+            "Experiencia con Python o SQL",
+            "Experiencia con AI/LLMs (prompting, evaluations, LangChain/LangGraph, etc.)",
+            "Experiencia en data engineering (modeling, ETL/ELT, data warehouse tools, etc.)"
+          ],
+          "benefits": [
+            "Compensación competitiva",
+            "Equity significativo — creemos en ownership compartido",
+            "Flexibilidad dentro de un modelo híbrido",
+            "La oportunidad de dar forma a un producto y a un sistema de AI desde cero",
+            "Una misión significativa: hacer que los datos sean útiles para las personas, no solo para analistas"
+          ],
+          "quickInfo": {
+            "location": "Buenos Aires (Híbrido)",
+            "department": "Decision Science"
+          }
+        }
+      ]
     }
   },
   "footer": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -202,7 +202,7 @@
           "slug": "decision-scientist-data-ai",
           "title": "Decision Scientist – Data & AI Implementation",
           "location": "Buenos Aires (Híbrido) • Full-time",
-          "applicationUrl": "https://forms.gle/grhyoFSdbetVZZvCA",
+          "applicationUrl": "https://forms.gle/FPadA7xBrfcKYMgM6",
           "aboutNivii": [
             "Imaginá que sos líder de un área en una gran compañía y es lunes a la mañana. Llegaron los resultados del mes pasado y no son los que esperábamos… tal vez bajaron los márgenes, subió el stock, el talento está rotando más rápido o la calidad del producto está sufriendo. Qué pasó es algo que la mayoría de las empresas sabe encontrar, pero el por qué y qué hacer es mucho más difícil y lento. Necesitabas respuestas profundas de tu data de manera instantánea, pero sin ellas volvés a depender solo de la intuición.",
             "En Nivii estamos repensando cómo las personas interactúan con los datos de negocio. Nuestro sistema de AI conversacional permite hacer preguntas en lenguaje natural y recibir respuestas claras, accionables, instantáneas y visuales. Combinando large language models, data orchestration y generación de gráficos en una sola interfaz, ayudamos a los equipos a pasar de datos a decisiones más rápido que nunca. No construimos un chatbot ni otro \"talk to your data\": construimos un thinking partner, una evolución del consulting tradicional.",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -197,7 +197,55 @@
         "notFoundPositionTitle": "Ops! Vaga Não Encontrada",
         "notFoundPositionDescription": "A vaga que você procura não existe ou já foi preenchida. Confira nossas vagas abertas para outras oportunidades."
       },
-      "openPositions": []
+      "openPositions": [
+        {
+          "slug": "decision-scientist-data-ai",
+          "title": "Decision Scientist – Data & AI Implementation",
+          "location": "Buenos Aires (Híbrido) • Full-time",
+          "applicationUrl": "https://forms.gle/grhyoFSdbetVZZvCA",
+          "aboutNivii": [
+            "Imagine que você é líder de uma área em uma grande empresa e é segunda-feira de manhã. Chegaram os resultados do mês passado e não são os que esperávamos... talvez as margens caíram, o estoque subiu, o talento está rotando mais rápido ou a qualidade do produto está sofrendo. O que aconteceu é algo que a maioria das empresas sabe encontrar, mas o porquê e o que fazer é muito mais difícil e lento. Você precisava de respostas profundas da sua data de maneira instantânea, mas sem elas você volta a depender apenas da intuição.",
+            "Na Nivii estamos repensando como as pessoas interagem com os dados de negócio. Nosso sistema de AI conversacional permite fazer perguntas em linguagem natural e receber respostas claras, acionáveis, instantâneas e visuais. Combinando large language models, data orchestration e geração de gráficos em uma única interface, ajudamos as equipes a passar de dados a decisões mais rápido do que nunca. Não construímos um chatbot nem outro \"talk to your data\": construímos um thinking partner, uma evolução do consulting tradicional.",
+            "Nosso produto já está em produção, com usuários reais em toda LATAM e tração inicial de equipes que precisam de respostas, não dashboards. Somos uma equipe pequena, prática, baseada em Buenos Aires, apaixonada pela usabilidade, clareza e por ajudar as pessoas a raciocinar melhor com dados."
+          ],
+          "aboutRole": [
+            "Buscamos alguém para se juntar à equipe de Decision Science. Somos a equipe que garante que nossos agentes retornem respostas realmente profundas e úteis. Para conseguir isso, precisamos garantir que tenham insumos limpos e confiáveis, caminhos de raciocínio bem desenhados e o contexto de negócio adequado.",
+            "É um papel híbrido: parte data, parte análise, parte experimentação com AI. Ideal para alguém que goste de variedade, prospere em ambientes early-stage e queira gerar um impacto material no nosso produto e no negócio dos nossos clientes."
+          ],
+          "responsibilities": [
+            "Fazer análise de dados: Ler os números, encontrar padrões relevantes e traduzi-los em insights claros e acionáveis",
+            "Iterar no desenvolvimento de agentes: Ajustar prompts, refinar raciocínios, testar melhorias, rodar avaliações e ajudar os agentes a responderem cada dia melhor",
+            "Desenhar e desenvolver ferramentas internas criativas: Criar utilidades e frameworks leves que impulsionem nosso trabalho com data: automatizar workflows investigativos, acelerar a detecção de padrões ou desenhar novas formas de interagir com a informação",
+            "Ajudar a dar forma ao produto: Trabalhar com a equipe de engenharia em features de produto e com a equipe comercial em entender necessidades de clientes e ajustar nossos sistemas de AI para resolvê-las da melhor maneira",
+            "Construir e manter data pipelines: Conectar fontes, modelar tabelas, assegurar qualidade de dados e alimentar nossos agentes com informação limpa e estruturada"
+          ],
+          "requirements": [
+            "Formação analítica muito sólida. Muitas pessoas nesta equipe vêm de engenharia, economia, planejamento ou papéis fortemente orientados a data",
+            "Você é uma pessoa muito curiosa que se auto-ensina quando precisa. Na fronteira do Gen AI isso acontece frequentemente: para resolver um problema é preciso aprender algo novo",
+            "Você tem facilidade para desmontar problemas e, quando vê algo que poderia funcionar melhor, tenta melhorá-lo",
+            "Você é um early adopter de AI (seja usuário de ChatGPT, Claude ou Gemini) e a usa com frequência... idealmente todos os dias",
+            "Você tem um ponto de vista sobre negócios. Talvez você poderia ter ido para consultoria estratégica (ou talvez foi), mas pelo menos com algumas pessoas do seu entorno você costuma ter conversas sobre negócio",
+            "Você mora em Buenos Aires e pode vir ao escritório uma vez por semana",
+            "Domínio de inglês e espanhol"
+          ],
+          "bonusPoints": [
+            "Experiência com Python ou SQL",
+            "Experiência com AI/LLMs (prompting, evaluations, LangChain/LangGraph, etc.)",
+            "Experiência em data engineering (modeling, ETL/ELT, data warehouse tools, etc.)"
+          ],
+          "benefits": [
+            "Compensação competitiva",
+            "Equity significativo — acreditamos em ownership compartilhado",
+            "Flexibilidade dentro de um modelo híbrido",
+            "A oportunidade de dar forma a um produto e a um sistema de AI desde o início",
+            "Uma missão significativa: fazer com que os dados sejam úteis para as pessoas, não só para analistas"
+          ],
+          "quickInfo": {
+            "location": "Buenos Aires (Híbrido)",
+            "department": "Decision Science"
+          }
+        }
+      ]
     }
   },
   "footer": {

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -202,7 +202,7 @@
           "slug": "decision-scientist-data-ai",
           "title": "Decision Scientist – Data & AI Implementation",
           "location": "Buenos Aires (Híbrido) • Full-time",
-          "applicationUrl": "https://forms.gle/grhyoFSdbetVZZvCA",
+          "applicationUrl": "https://forms.gle/FPadA7xBrfcKYMgM6",
           "aboutNivii": [
             "Imagine que você é líder de uma área em uma grande empresa e é segunda-feira de manhã. Chegaram os resultados do mês passado e não são os que esperávamos... talvez as margens caíram, o estoque subiu, o talento está rotando mais rápido ou a qualidade do produto está sofrendo. O que aconteceu é algo que a maioria das empresas sabe encontrar, mas o porquê e o que fazer é muito mais difícil e lento. Você precisava de respostas profundas da sua data de maneira instantânea, mas sem elas você volta a depender apenas da intuição.",
             "Na Nivii estamos repensando como as pessoas interagem com os dados de negócio. Nosso sistema de AI conversacional permite fazer perguntas em linguagem natural e receber respostas claras, acionáveis, instantâneas e visuais. Combinando large language models, data orchestration e geração de gráficos em uma única interface, ajudamos as equipes a passar de dados a decisões mais rápido do que nunca. Não construímos um chatbot nem outro \"talk to your data\": construímos um thinking partner, uma evolução do consulting tradicional.",


### PR DESCRIPTION
## Qué hace
Reabre la posición **Decision Scientist – Data & AI Implementation** en la página de careers. El array `openPositions` estaba vacío (todas las vacantes cerradas); esto restaura el rol en los 3 idiomas (en/es/pt).

## Ediciones aplicadas al reabrir
- **Título** unificado a "Decision Scientist" en todos los idiomas (ES/PT antes decían "Decision Science").
- **"language models" → "large language models"** en la sección About Nivii.
- **Ejemplo de early-adopter de AI: Grok → Gemini** en los requisitos.

## Notas
- `quickInfo.department` se dejó a propósito como "Decision Science" (nombre del equipo).
- URL del formulario de aplicación sin cambios: https://forms.gle/grhyoFSdbetVZZvCA

🤖 Generated with [Claude Code](https://claude.com/claude-code)
